### PR TITLE
fix wrong version tag for container images.

### DIFF
--- a/src/guide/quick_start/docker.md
+++ b/src/guide/quick_start/docker.md
@@ -18,7 +18,7 @@ This section introduces how to quickly experience openGemini through Docker at f
    Or specify a version of the container image:
 
    ```shell
-   > docker run -d --name opengemini opengeminidb/opengemini-server:v1.0.1
+   > docker run -d --name opengemini opengeminidb/opengemini-server:1.0.1
    ```
 
 3. Connect to openGemini cli:

--- a/src/zh/guide/quick_start/docker.md
+++ b/src/zh/guide/quick_start/docker.md
@@ -18,7 +18,7 @@ order: 2
    或者指定版本的容器镜像：
 
    ```shell
-   docker run -d --name opengemini opengeminidb/opengemini-server:v1.0.1
+   docker run -d --name opengemini opengeminidb/opengemini-server:1.0.1
    ```
 
 3. 使用openGemini cli 连接：


### PR DESCRIPTION

```
$ docker pull opengeminidb/opengemini-server:v1.0.1
Error response from daemon: manifest for opengeminidb/opengemini-server:v1.0.1 not found: manifest unknown: manifest unknown
$ docker pull opengeminidb/opengemini-server:1.0.1
1.0.1: Pulling from opengeminidb/opengemini-server
Digest: sha256:df832ecf80e20eef00c3d595f0484a01368aba164c3b1ad9e0ed9632b07b611a
Status: Image is up to date for opengeminidb/opengemini-server:1.0.1
docker.io/opengeminidb/opengemini-server:1.0.1
```

the container image tags have not prefix `v`.
